### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/C0piIot/gasapp/security/code-scanning/3](https://github.com/C0piIot/gasapp/security/code-scanning/3)

To fix this issue, we should add an explicit `permissions` block to the workflow. The best way is to set it at the top level, after the workflow name and before `jobs`, because this restricts permissions for all jobs unless overridden. A minimal permission set for build workflows is usually `contents: read`, unless specific steps require more. Since the provided workflow does not indicate any need for writable permissions (e.g., updating pull requests, issues, or repository contents), we will set this as the value.

Edit `.github/workflows/build.yml`, adding the following block:

```yaml
permissions:
  contents: read
```

directly after the `name: Build` and before `on:` (usually line 2 or 3).

No imports or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
