### PR TITLE
Run tests on non-draft pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Test
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test ./...


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` — a `Test` workflow that runs `go test ./...` on every PR event (opened, synchronize, reopened, ready_for_review).
- Drafts are skipped via `if: github.event.pull_request.draft == false`, so WIP PRs don't burn CI minutes.
- The step set mirrors the `test` job in `build.yml` (checkout → setup-go from `go.mod` → `go test ./...`).

## Test plan
- [ ] Confirm this PR itself triggers the new workflow and that the `test` job runs and passes.
- [ ] Mark the PR as draft and re-push — confirm the workflow does NOT run.
- [ ] Mark it ready for review again — confirm the workflow runs (validates the `ready_for_review` trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)