### PR TITLE
Persist SQLite on a Fly volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,7 @@ COPY --from=build /out/server ./server
 COPY templates/ templates/
 COPY static/    static/
 
+RUN mkdir -p /data
+
 EXPOSE 8080
-CMD ["./server", "-addr=:8080"]
+CMD ["./server", "-addr=:8080", "-db=/data/db.sqlite3"]

--- a/fly.toml
+++ b/fly.toml
@@ -9,6 +9,10 @@ kill_timeout = "5s"
   internal_port = 8080
   force_https = true
 
+[[mounts]]
+  source = "data"
+  destination = "/data"
+
 [[statics]]
   guest_path = "/app/static"
   url_prefix = "/static"


### PR DESCRIPTION
## Summary
- Mount a Fly volume at \`/data\` and point the server at \`/data/db.sqlite3\` so the SQLite file (now including \`price_history\`) survives deploys and machine restarts.
- Adds the \`[[mounts]]\` block in \`fly.toml\`, creates \`/data\` in the Dockerfile, and passes \`-db=/data/db.sqlite3\` in the runtime CMD. Local dev (\`go run ./cmd/server\`) is unaffected — the flag default is still \`db.sqlite3\`.

## Before merging / deploying
Run once to create the volume in the primary region:

\`\`\`
fly volumes create data --region cdg --size 1
\`\`\`

Without the volume the machine will fail to start because the mount target won't exist.

## Notes / assumptions
- Single-machine deployment (volumes are pinned 1:1 to a machine in one region). If we later scale out, we'll need LiteFS or a different storage strategy — out of scope here.
- First boot on the new volume starts with an empty DB; the existing hourly \`UpdatePrices\` cycle re-populates \`stations\` and seeds \`price_history\` from then on. No data migration needed because today's storage is already ephemeral.

## Test plan
- [ ] \`fly volumes create data --region cdg --size 1\`
- [ ] \`fly deploy\` and confirm the machine boots with the volume attached (\`fly ssh console -C 'ls -la /data'\` shows \`db.sqlite3\` after the first hourly update).
- [ ] After one update cycle, \`fly ssh console -C 'sqlite3 /data/db.sqlite3 "SELECT COUNT(*) FROM stations; SELECT COUNT(*) FROM price_history;"'\` returns non-zero counts.
- [ ] Trigger a redeploy and confirm both counts are preserved.