### PR TITLE
Add favorite stations saved to localStorage

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -133,7 +133,24 @@ func stationsHandler(sc *stationCache) http.HandlerFunc {
 		}
 
 		result := stations
-		if center := r.URL.Query().Get("center"); center != "" {
+		if r.URL.Query().Has("ids") {
+			raw := r.URL.Query().Get("ids")
+			parts := strings.Split(raw, ",")
+			byID := make(map[int64]station.Station, len(stations))
+			for _, s := range stations {
+				byID[s.ID] = s
+			}
+			result = make([]station.Station, 0, len(parts))
+			for _, p := range parts {
+				id, err := strconv.ParseInt(p, 10, 64)
+				if err != nil {
+					continue
+				}
+				if s, ok := byID[id]; ok {
+					result = append(result, s)
+				}
+			}
+		} else if center := r.URL.Query().Get("center"); center != "" {
 			parts := strings.SplitN(center, ",", 2)
 			if len(parts) == 2 {
 				lng, errLng := strconv.ParseFloat(parts[0], 64)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -66,6 +66,92 @@ func TestStationsHandlerInvalidCenter(t *testing.T) {
 	}
 }
 
+func TestStationsHandlerByIDs(t *testing.T) {
+	database := newTestDB(t)
+	insertStation(t, database, 1, 40.0, -3.0, 1.5)
+	insertStation(t, database, 2, 41.0, -3.0, 1.6)
+	insertStation(t, database, 3, 42.0, -3.0, 1.7)
+
+	sc := &stationCache{db: database}
+	w := doRequest(t, sc, "/stations/?ids=3,1,99")
+
+	rows := decodeStations(t, w)
+	if len(rows) != 2 {
+		t.Fatalf("got %d stations, want 2 (unknown ID 99 must be skipped)", len(rows))
+	}
+	if id := int64(rows[0][0].(float64)); id != 3 {
+		t.Errorf("rows[0] ID = %d, want 3 (request order preserved)", id)
+	}
+	if id := int64(rows[1][0].(float64)); id != 1 {
+		t.Errorf("rows[1] ID = %d, want 1", id)
+	}
+}
+
+func TestStationsHandlerByIDsOverridesCenter(t *testing.T) {
+	database := newTestDB(t)
+	insertStation(t, database, 1, 40.0, -3.0, 1.5)
+	insertStation(t, database, 2, 41.0, -3.0, 1.6)
+
+	sc := &stationCache{db: database}
+	w := doRequest(t, sc, "/stations/?ids=2&center=-3.0,40.0")
+
+	rows := decodeStations(t, w)
+	if len(rows) != 1 {
+		t.Fatalf("got %d stations, want 1 (ids must override center)", len(rows))
+	}
+	if id := int64(rows[0][0].(float64)); id != 2 {
+		t.Errorf("ID = %d, want 2", id)
+	}
+}
+
+func TestStationsHandlerByIDsEmpty(t *testing.T) {
+	database := newTestDB(t)
+	insertStation(t, database, 1, 40.0, -3.0, 1.5)
+
+	sc := &stationCache{db: database}
+	w := doRequest(t, sc, "/stations/?ids=")
+
+	rows := decodeStations(t, w)
+	if len(rows) != 0 {
+		t.Errorf("got %d stations, want 0 for empty ids", len(rows))
+	}
+}
+
+func TestStationsHandlerByIDsMalformed(t *testing.T) {
+	database := newTestDB(t)
+	insertStation(t, database, 1, 40.0, -3.0, 1.5)
+
+	sc := &stationCache{db: database}
+	w := doRequest(t, sc, "/stations/?ids=abc,xyz")
+
+	rows := decodeStations(t, w)
+	if len(rows) != 0 {
+		t.Errorf("got %d stations, want 0 for malformed ids", len(rows))
+	}
+}
+
+func TestStationsHandlerByIDsDoesNotMutateCache(t *testing.T) {
+	database := newTestDB(t)
+	insertStation(t, database, 1, 40.0, -3.0, 1.5)
+	insertStation(t, database, 2, 41.0, -3.0, 1.6)
+
+	sc := &stationCache{db: database}
+	// Prime the cache.
+	if _, err := sc.get(); err != nil {
+		t.Fatal(err)
+	}
+
+	doRequest(t, sc, "/stations/?ids=2")
+
+	stations, err := sc.get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stations) != 2 {
+		t.Errorf("cache size = %d, want 2 (filter must not mutate the shared slice)", len(stations))
+	}
+}
+
 func TestStationCacheInvalidate(t *testing.T) {
 	database := newTestDB(t)
 	sc := &stationCache{db: database}

--- a/templates/home.html
+++ b/templates/home.html
@@ -149,6 +149,7 @@
         fuel = localStorage.getItem('fuel') || 'petrol95',
         currentStationId = null,
         favoritesRequestId = 0,
+        favoritesPromise = null,
         lat, lon, stationId;
     [lat, lon, stationId] = location.hash.replace('#','').split(',', 3);
     const savedView = (() => {
@@ -176,9 +177,31 @@
     function toggleFavorite(pk) {
         pk = Number(pk);
         const favs = loadFavorites(),
-            idx = favs.indexOf(pk);
-        if (idx === -1) favs.unshift(pk); else favs.splice(idx, 1);
+            idx = favs.indexOf(pk),
+            added = idx === -1;
+        if (added) favs.unshift(pk); else favs.splice(idx, 1);
         saveFavorites(favs);
+        if (added) refreshFavorites();
+    }
+    function refreshFavorites() {
+        const ids = loadFavorites();
+        const p = (async () => {
+            if (ids.length === 0) return new Map();
+            const url = stationsUrl + '?ids=' + ids.join(','),
+                response = await (await fetch(url)).json(),
+                byId = new Map();
+            response.stations.forEach((row) => {
+                const s = {};
+                [s.pk, s.name, s.petrol95, s.petrol98, s.gasoil, s.glp,
+                 s.address, s.city, s.postal_code, s.location, s.updated] = row;
+                s.location = [s.location[1], s.location[0]];
+                byId.set(s.pk, s);
+            });
+            return byId;
+        })();
+        p.resolved = false;
+        p.then(() => { p.resolved = true; }, () => { p.resolved = true; });
+        favoritesPromise = p;
     }
     function updateFavoriteToggle(pk) {
         if (pk === null || pk === undefined) return;
@@ -258,27 +281,19 @@
             empty.classList.remove('hidden');
             return;
         }
-        loading.classList.remove('hidden');
-        const url = stationsUrl + '?ids=' + favs.join(',') + '&fuel=' + fuel,
-            response = await (await fetch(url)).json();
+        if (!favoritesPromise) refreshFavorites();
+        if (!favoritesPromise.resolved) loading.classList.remove('hidden');
+        const byId = await favoritesPromise;
         if (myId !== favoritesRequestId) return;
         loading.classList.add('hidden');
-        const byId = {};
-        response.stations.forEach((row) => {
-            const s = {};
-            [s.pk, s.name, s.petrol95, s.petrol98, s.gasoil, s.glp,
-             s.address, s.city, s.postal_code, s.location, s.updated] = row;
-            s.location = [s.location[1], s.location[0]];
-            byId[s.pk] = s;
-        });
-        const validFavs = favs.filter(id => id in byId);
+        const validFavs = favs.filter(id => byId.has(id));
         if (validFavs.length !== favs.length) saveFavorites(validFavs);
         if (validFavs.length === 0) {
             empty.classList.remove('hidden');
             return;
         }
         validFavs.forEach((id) => {
-            const s = byId[id],
+            const s = byId.get(id),
                 li = document.createElement('li'),
                 row = document.createElement('button'),
                 name = document.createElement('span'),
@@ -436,6 +451,7 @@
         map.locate({setView: true, maxZoom: 13, enableHighAccuracy: true, maximumAge: 10});
     }
     updateStations();
+    if (loadFavorites().length > 0) refreshFavorites();
 
     map.attributionControl.setPrefix(false);
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -33,9 +33,30 @@
             color: inherit;
             margin-left: 1rem;
         }
-        #station-info, #fuel-selector { padding: 1rem; }
+        #station-info, #fuel-selector, #favorites { padding: 1rem; }
         #station-info p.prices>span { white-space: nowrap; margin-right: 12px; }
         #fuel-selector p { margin-top: 1rem; text-align: center;}
+        #favorite-toggle, #favorites-close {
+            background: none; border: none; cursor: pointer;
+            font-size: 1.4rem; line-height: 1;
+            padding: 0; margin-left: 1rem; color: inherit;
+        }
+        #favorites ul { list-style: none; padding: 0; margin: 0.5rem 0 0; max-height: 60vh; overflow-y: auto; }
+        #favorites li { display: flex; align-items: stretch; border-bottom: 1px solid #eee; }
+        #favorites .row {
+            flex: 1; background: none; border: none; cursor: pointer;
+            padding: 0.6rem 0.4rem; text-align: left; color: inherit;
+            display: grid; grid-template-columns: 1fr auto; column-gap: 0.5rem;
+            font-size: 0.95rem;
+        }
+        #favorites .row .name { font-weight: bold; grid-column: 1; }
+        #favorites .row .city { grid-column: 1; font-size: 0.8rem; color: #666; }
+        #favorites .row .price { grid-column: 2; grid-row: 1 / span 2; align-self: center; font-weight: bold; }
+        #favorites .remove {
+            background: none; border: none; cursor: pointer;
+            padding: 0 0.8rem; font-size: 1.4rem; color: #888;
+        }
+        #favorites p.empty, #favorites p.loading { margin: 0.5rem 0; color: #666; font-size: 0.9rem; }
         .station {
             padding: 0.2rem;
             background: white;
@@ -83,7 +104,7 @@
 <body data-build="{{.BuildVersion}}">
 <div id="map"></div>
 <div id="station-info" class="hidden">
-    <h1><span></span><a href="#" title="Compartir" class="hidden"><i class="fa fa-share"></i></a></h1>
+    <h1><span></span><button type="button" id="favorite-toggle" title="Favorito" aria-label="Favorito">☆</button><a href="#" title="Compartir" class="hidden"><i class="fa fa-share"></i></a></h1>
     <p class="prices">
         <span id="petrol95"><i class="fa fa-gas-station"></i> 95 <b></b></span>
         <span id="petrol98"><i class="fa fa-gas-station"></i> 98 <b></b></span>
@@ -95,6 +116,12 @@
         <a href="#" target="_blank" id="directions"><i class="fa fa-navigation"></i> Get directions</a>
     </address>
     <p id="updated">Actualizado: <span></span></p>
+</div>
+<div id="favorites" class="hidden">
+    <h1>Favoritos<button type="button" id="favorites-close" aria-label="Cerrar">×</button></h1>
+    <p class="loading hidden">Cargando…</p>
+    <p class="empty hidden">Aún no tienes favoritos. Toca la estrella en una estación para añadirla.</p>
+    <ul></ul>
 </div>
 <div id="fuel-selector" class="hidden">
     <h1>Combustible preferido</h1>
@@ -120,6 +147,8 @@
         latestFetchTime = 0,
         markers = {},
         fuel = localStorage.getItem('fuel') || 'petrol95',
+        currentStationId = null,
+        favoritesRequestId = 0,
         lat, lon, stationId;
     [lat, lon, stationId] = location.hash.replace('#','').split(',', 3);
     const savedView = (() => {
@@ -131,31 +160,161 @@
         } catch (e) {}
         return null;
     })();
+    function loadFavorites() {
+        try {
+            const f = JSON.parse(localStorage.getItem('favorites'));
+            if (Array.isArray(f)) return f.filter(x => Number.isFinite(x));
+        } catch (e) {}
+        return [];
+    }
+    function saveFavorites(favs) {
+        localStorage.setItem('favorites', JSON.stringify(favs));
+    }
+    function isFavorite(pk) {
+        return loadFavorites().includes(Number(pk));
+    }
+    function toggleFavorite(pk) {
+        pk = Number(pk);
+        const favs = loadFavorites(),
+            idx = favs.indexOf(pk);
+        if (idx === -1) favs.unshift(pk); else favs.splice(idx, 1);
+        saveFavorites(favs);
+    }
+    function updateFavoriteToggle(pk) {
+        if (pk === null || pk === undefined) return;
+        qs('#favorite-toggle').textContent = isFavorite(pk) ? '★' : '☆';
+    }
     const qs = s =>  document.querySelector(s),
         shareAnchor = qs('#station-info h1 a'),
         stationsUrl = "/stations/",
         iconTemplate = qs('#icon').innerHTML,
         ios = /iPad|iPhone|iPod|Darwin/.test(navigator.platform) && !window.MSStream,
         currencyOptions = { style: 'currency', currency: 'EUR', minimumFractionDigits: 3},
-        FuelControl = L.Control.extend({
+        ToolsControl = L.Control.extend({
             options: { position: 'topright' },
-            onAdd: (map) => {
-                var container = L.DomUtil.create('div', 'leaflet-control leaflet-bar');
-                link = L.DomUtil.create('a', '', container);
+            onAdd: () => {
+                const container = L.DomUtil.create('div', 'leaflet-control leaflet-bar'),
+                    fuelLink = L.DomUtil.create('a', '', container),
+                    favLink = L.DomUtil.create('a', '', container);
 
-                link.href = '#';
-                link.title = 'Carburante preferido';
-                link.innerHTML = '<i class="fa fa-gas-station"></i>';
-
-                L.DomEvent.on(link, 'click', L.DomEvent.stop).on(link, 'click', () => {
+                fuelLink.href = '#';
+                fuelLink.title = 'Carburante preferido';
+                fuelLink.innerHTML = '<i class="fa fa-gas-station"></i>';
+                L.DomEvent.on(fuelLink, 'click', L.DomEvent.stop).on(fuelLink, 'click', () => {
                     qs('#fuel-selector select').value = fuel;
                     qs('#fuel-selector').classList.remove('hidden');
                     qs('#station-info').classList.add('hidden');
+                    qs('#favorites').classList.add('hidden');
                 });
+
+                favLink.href = '#';
+                favLink.title = 'Favoritos';
+                favLink.style.fontSize = '1.2rem';
+                favLink.style.lineHeight = '26px';
+                favLink.innerHTML = '★';
+                L.DomEvent.on(favLink, 'click', L.DomEvent.stop).on(favLink, 'click', openFavorites);
 
                 return container;
             }
         });
+    function showStation(s) {
+        currentStationId = s.pk;
+        qs('#station-info h1 span').textContent = s.name;
+        const location = s.location.join();
+        qs('#station-info address p').textContent = [s.address, s.postal_code, s.city].join(', ');
+        ['petrol95', 'petrol98', 'gasoil', 'glp'].forEach((k) => {
+            if (s[k]) {
+                qs('#' + k + ' b').textContent = s[k].toLocaleString('es', currencyOptions);
+            }
+            qs('#' + k).classList.toggle('hidden', !s[k]);
+        });
+        qs('#station-info').classList.remove('hidden');
+        qs('#fuel-selector').classList.add('hidden');
+        qs('#favorites').classList.add('hidden');
+        if (ios) {
+            qs('#directions').href = `https://maps.apple.com/?daddr=${location}&dirflg=d`;
+        } else {
+            qs('#directions').href = `https://www.google.com/maps/dir/?api=1&destination=${location}&travelmode=driving&dir_action=navigate`;
+        }
+        qs('#updated span').textContent = new Date(s.updated * 1000).toLocaleDateString('es', {});
+        shareAnchor.href = `/#${location},${s.pk}`;
+        shareAnchor.title = `⛽ ${s.name}`;
+        updateFavoriteToggle(s.pk);
+    }
+    async function openFavorites() {
+        const myId = ++favoritesRequestId;
+        qs('#station-info').classList.add('hidden');
+        qs('#fuel-selector').classList.add('hidden');
+        const panel = qs('#favorites'),
+            list = panel.querySelector('ul'),
+            empty = panel.querySelector('.empty'),
+            loading = panel.querySelector('.loading');
+        panel.classList.remove('hidden');
+        list.replaceChildren();
+        empty.classList.add('hidden');
+        loading.classList.add('hidden');
+        const favs = loadFavorites();
+        if (favs.length === 0) {
+            empty.classList.remove('hidden');
+            return;
+        }
+        loading.classList.remove('hidden');
+        const url = stationsUrl + '?ids=' + favs.join(',') + '&fuel=' + fuel,
+            response = await (await fetch(url)).json();
+        if (myId !== favoritesRequestId) return;
+        loading.classList.add('hidden');
+        const byId = {};
+        response.stations.forEach((row) => {
+            const s = {};
+            [s.pk, s.name, s.petrol95, s.petrol98, s.gasoil, s.glp,
+             s.address, s.city, s.postal_code, s.location, s.updated] = row;
+            s.location = [s.location[1], s.location[0]];
+            byId[s.pk] = s;
+        });
+        const validFavs = favs.filter(id => id in byId);
+        if (validFavs.length !== favs.length) saveFavorites(validFavs);
+        if (validFavs.length === 0) {
+            empty.classList.remove('hidden');
+            return;
+        }
+        validFavs.forEach((id) => {
+            const s = byId[id],
+                li = document.createElement('li'),
+                row = document.createElement('button'),
+                name = document.createElement('span'),
+                city = document.createElement('span'),
+                price = document.createElement('span'),
+                remove = document.createElement('button');
+            li.dataset.id = id;
+            row.type = 'button';
+            row.className = 'row';
+            name.className = 'name';
+            name.textContent = s.name;
+            city.className = 'city';
+            city.textContent = [s.city, s.postal_code].filter(Boolean).join(', ');
+            price.className = 'price';
+            price.textContent = s[fuel] ? s[fuel].toLocaleString('es', currencyOptions) : '--';
+            row.append(name, city, price);
+            row.addEventListener('click', () => {
+                panel.classList.add('hidden');
+                map.setView(s.location, 15);
+                showStation(s);
+            });
+            remove.type = 'button';
+            remove.className = 'remove';
+            remove.setAttribute('aria-label', 'Quitar');
+            remove.textContent = '×';
+            remove.addEventListener('click', (e) => {
+                e.stopPropagation();
+                toggleFavorite(id);
+                li.remove();
+                if (loadFavorites().length === 0) empty.classList.remove('hidden');
+                if (currentStationId === id) updateFavoriteToggle(currentStationId);
+            });
+            li.append(row, remove);
+            list.appendChild(li);
+        });
+    }
     async function updateStations(force) {
         const params = new URLSearchParams(),
             center = map.getBounds().getCenter();
@@ -189,6 +348,7 @@
                 s.location,
                 s.updated
             ] = station;
+            s.location = [s.location[1], s.location[0]];
             if(s[fuel]){
                 minPrice = Math.min(s[fuel], minPrice);
                 maxPrice = Math.max(s[fuel], maxPrice);
@@ -198,33 +358,11 @@
                 newMarkers[s.pk] = markers[s.pk];
                 delete markers[s.pk];
             } else {
-                const template = iconTemplate.replace('{price}', (s[fuel]|| '--').toLocaleString('es', currencyOptions)),
-                    showMarker = () => {
-                        qs('#station-info h1 span').textContent = s.name;
-                        const address = [ s.address, s.postal_code, s.city ],
-                            location = s.location.join();
-                        qs('#station-info address p').textContent = address.join(', ');
-                        ['petrol95', 'petrol98', 'gasoil', 'glp'].forEach((k) => {
-                            if(s[k]){
-                                qs('#' + k + ' b').textContent = s[k].toLocaleString('es', currencyOptions);
-                            }
-                            qs('#' + k).classList.toggle('hidden', !s[k]);
-                        });
-                        qs('#station-info').classList.remove('hidden');
-                        qs('#fuel-selector').classList.add('hidden');
-                        if(ios){
-                            qs('#directions').href = `https://maps.apple.com/?daddr=${location}&dirflg=d`;
-                        } else {
-                            qs('#directions').href = `https://www.google.com/maps/dir/?api=1&destination=${location}&travelmode=driving&dir_action=navigate`;
-                        }
-                        qs('#updated span').textContent = new Date(s.updated * 1000).toLocaleDateString('es', {});
-                        shareAnchor.href = `/#${location},${s.pk}`;
-                        shareAnchor.title = `⛽ ${s.name}`;
-                    };
+                const template = iconTemplate.replace('{price}', (s[fuel]|| '--').toLocaleString('es', currencyOptions));
                 if(stationId == s.pk){
-                    showMarker();
+                    showStation(s);
                 }
-                newMarkers[s.pk] = L.marker(s.location.reverse(), {
+                newMarkers[s.pk] = L.marker(s.location, {
                     title: s.name,
                     alt: s.name,
                     price: s[fuel]|| false,
@@ -236,7 +374,7 @@
                     })
                 })
                 .addTo(map)
-                .on('click', showMarker);
+                .on('click', () => showStation(s));
             }
         });
         for(k in markers){
@@ -283,8 +421,12 @@
                 }
             }))
         .addControl(L.control.zoom({position:'topright'}))
-        .addControl(new FuelControl())
-        .on('click', () => { qs('#station-info').classList.add('hidden'); qs('#fuel-selector').classList.add('hidden'); })
+        .addControl(new ToolsControl())
+        .on('click', () => {
+            qs('#station-info').classList.add('hidden');
+            qs('#fuel-selector').classList.add('hidden');
+            qs('#favorites').classList.add('hidden');
+        })
         .on('moveend', () => {
             const c = map.getCenter();
             localStorage.setItem('view', JSON.stringify({lat: c.lat, lon: c.lng, zoom: map.getZoom()}));
@@ -306,6 +448,16 @@
         markers = [];
         qs('#fuel-selector').classList.add('hidden');
         updateStations(true);
+    });
+
+    qs('#favorite-toggle').addEventListener('click', () => {
+        if (currentStationId === null) return;
+        toggleFavorite(currentStationId);
+        updateFavoriteToggle(currentStationId);
+    });
+
+    qs('#favorites-close').addEventListener('click', () => {
+        qs('#favorites').classList.add('hidden');
     });
 
     if ('share' in navigator) {

--- a/templates/home.html
+++ b/templates/home.html
@@ -139,6 +139,16 @@
     <i class="fa fa-gas-station"></i>
     <div>{price}</div>
 </template>
+<template id="favorite-row">
+    <li>
+        <button type="button" class="row">
+            <span class="name"></span>
+            <span class="city"></span>
+            <span class="price"></span>
+        </button>
+        <button type="button" class="remove" aria-label="Quitar">×</button>
+    </li>
+</template>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/leaflet.locatecontrol@0.79.0/dist/L.Control.Locate.min.js" charset="utf-8"></script>
 <script src="https://cdn.jsdelivr.net/npm/leaflet-edgebuffer@1.0.1/src/leaflet.edgebuffer.js"></script>
@@ -292,41 +302,26 @@
             empty.classList.remove('hidden');
             return;
         }
+        const rowTemplate = qs('#favorite-row');
         validFavs.forEach((id) => {
             const s = byId.get(id),
-                li = document.createElement('li'),
-                row = document.createElement('button'),
-                name = document.createElement('span'),
-                city = document.createElement('span'),
-                price = document.createElement('span'),
-                remove = document.createElement('button');
+                li = rowTemplate.content.firstElementChild.cloneNode(true);
             li.dataset.id = id;
-            row.type = 'button';
-            row.className = 'row';
-            name.className = 'name';
-            name.textContent = s.name;
-            city.className = 'city';
-            city.textContent = [s.city, s.postal_code].filter(Boolean).join(', ');
-            price.className = 'price';
-            price.textContent = s[fuel] ? s[fuel].toLocaleString('es', currencyOptions) : '--';
-            row.append(name, city, price);
-            row.addEventListener('click', () => {
+            li.querySelector('.name').textContent = s.name;
+            li.querySelector('.city').textContent = [s.city, s.postal_code].filter(Boolean).join(', ');
+            li.querySelector('.price').textContent = s[fuel] ? s[fuel].toLocaleString('es', currencyOptions) : '--';
+            li.querySelector('.row').addEventListener('click', () => {
                 panel.classList.add('hidden');
                 map.setView(s.location, 15);
                 showStation(s);
             });
-            remove.type = 'button';
-            remove.className = 'remove';
-            remove.setAttribute('aria-label', 'Quitar');
-            remove.textContent = '×';
-            remove.addEventListener('click', (e) => {
+            li.querySelector('.remove').addEventListener('click', (e) => {
                 e.stopPropagation();
                 toggleFavorite(id);
                 li.remove();
                 if (loadFavorites().length === 0) empty.classList.remove('hidden');
                 if (currentStationId === id) updateFavoriteToggle(currentStationId);
             });
-            li.append(row, remove);
             list.appendChild(li);
         });
     }

--- a/templates/home.html
+++ b/templates/home.html
@@ -36,7 +36,7 @@
         #station-info, #fuel-selector, #favorites { padding: 1rem; }
         #station-info p.prices>span { white-space: nowrap; margin-right: 12px; }
         #fuel-selector p { margin-top: 1rem; text-align: center;}
-        #favorite-toggle, #favorites-close {
+        #favorite-toggle {
             background: none; border: none; cursor: pointer;
             font-size: 1.4rem; line-height: 1;
             padding: 0; margin-left: 1rem; color: inherit;
@@ -118,7 +118,7 @@
     <p id="updated">Actualizado: <span></span></p>
 </div>
 <div id="favorites" class="hidden">
-    <h1>Favoritos<button type="button" id="favorites-close" aria-label="Cerrar">×</button></h1>
+    <h1>Favoritos</h1>
     <p class="loading hidden">Cargando…</p>
     <p class="empty hidden">Aún no tienes favoritos. Toca la estrella en una estación para añadirla.</p>
     <ul></ul>
@@ -158,7 +158,6 @@
         markers = {},
         fuel = localStorage.getItem('fuel') || 'petrol95',
         currentStationId = null,
-        favoritesRequestId = 0,
         lat, lon, stationId;
     [lat, lon, stationId] = location.hash.replace('#','').split(',', 3);
     const savedView = (() => {
@@ -193,8 +192,7 @@
         if (currentStationId === pk) updateFavoriteToggle(pk);
     }
     async function renderFavorites() {
-        const myId = ++favoritesRequestId,
-            ids = loadFavorites(),
+        const ids = loadFavorites(),
             panel = qs('#favorites'),
             list = panel.querySelector('ul'),
             empty = panel.querySelector('.empty'),
@@ -209,7 +207,6 @@
         if (list.children.length === 0) loading.classList.remove('hidden');
         const url = stationsUrl + '?ids=' + ids.join(','),
             response = await (await fetch(url)).json();
-        if (myId !== favoritesRequestId) return;
         const byId = new Map();
         response.stations.forEach((row) => {
             const s = {};
@@ -452,10 +449,6 @@
 
     qs('#favorite-toggle').addEventListener('click', () => {
         if (currentStationId !== null) toggleFavorite(currentStationId);
-    });
-
-    qs('#favorites-close').addEventListener('click', () => {
-        qs('#favorites').classList.add('hidden');
     });
 
     if ('share' in navigator) {

--- a/templates/home.html
+++ b/templates/home.html
@@ -159,7 +159,6 @@
         fuel = localStorage.getItem('fuel') || 'petrol95',
         currentStationId = null,
         favoritesRequestId = 0,
-        favoritesPromise = null,
         lat, lon, stationId;
     [lat, lon, stationId] = location.hash.replace('#','').split(',', 3);
     const savedView = (() => {
@@ -187,31 +186,66 @@
     function toggleFavorite(pk) {
         pk = Number(pk);
         const favs = loadFavorites(),
-            idx = favs.indexOf(pk),
-            added = idx === -1;
-        if (added) favs.unshift(pk); else favs.splice(idx, 1);
+            idx = favs.indexOf(pk);
+        if (idx === -1) favs.unshift(pk); else favs.splice(idx, 1);
         saveFavorites(favs);
-        if (added) refreshFavorites();
+        renderFavorites();
+        if (currentStationId === pk) updateFavoriteToggle(pk);
     }
-    function refreshFavorites() {
-        const ids = loadFavorites();
-        const p = (async () => {
-            if (ids.length === 0) return new Map();
-            const url = stationsUrl + '?ids=' + ids.join(','),
-                response = await (await fetch(url)).json(),
-                byId = new Map();
-            response.stations.forEach((row) => {
-                const s = {};
-                [s.pk, s.name, s.petrol95, s.petrol98, s.gasoil, s.glp,
-                 s.address, s.city, s.postal_code, s.location, s.updated] = row;
-                s.location = [s.location[1], s.location[0]];
-                byId.set(s.pk, s);
+    async function renderFavorites() {
+        const myId = ++favoritesRequestId,
+            ids = loadFavorites(),
+            panel = qs('#favorites'),
+            list = panel.querySelector('ul'),
+            empty = panel.querySelector('.empty'),
+            loading = panel.querySelector('.loading');
+        if (ids.length === 0) {
+            list.replaceChildren();
+            loading.classList.add('hidden');
+            empty.classList.remove('hidden');
+            return;
+        }
+        empty.classList.add('hidden');
+        if (list.children.length === 0) loading.classList.remove('hidden');
+        const url = stationsUrl + '?ids=' + ids.join(','),
+            response = await (await fetch(url)).json();
+        if (myId !== favoritesRequestId) return;
+        const byId = new Map();
+        response.stations.forEach((row) => {
+            const s = {};
+            [s.pk, s.name, s.petrol95, s.petrol98, s.gasoil, s.glp,
+             s.address, s.city, s.postal_code, s.location, s.updated] = row;
+            s.location = [s.location[1], s.location[0]];
+            byId.set(s.pk, s);
+        });
+        const validFavs = ids.filter(id => byId.has(id));
+        if (validFavs.length !== ids.length) saveFavorites(validFavs);
+        loading.classList.add('hidden');
+        if (validFavs.length === 0) {
+            list.replaceChildren();
+            empty.classList.remove('hidden');
+            return;
+        }
+        const tpl = qs('#favorite-row'),
+            rows = validFavs.map((id) => {
+                const s = byId.get(id),
+                    li = tpl.content.firstElementChild.cloneNode(true);
+                li.dataset.id = id;
+                li.querySelector('.name').textContent = s.name;
+                li.querySelector('.city').textContent = [s.city, s.postal_code].filter(Boolean).join(', ');
+                li.querySelector('.price').textContent = s[fuel] ? s[fuel].toLocaleString('es', currencyOptions) : '--';
+                li.querySelector('.row').addEventListener('click', () => {
+                    panel.classList.add('hidden');
+                    map.setView(s.location, 15);
+                    showStation(s);
+                });
+                li.querySelector('.remove').addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    toggleFavorite(id);
+                });
+                return li;
             });
-            return byId;
-        })();
-        p.resolved = false;
-        p.then(() => { p.resolved = true; }, () => { p.resolved = true; });
-        favoritesPromise = p;
+        list.replaceChildren(...rows);
     }
     function updateFavoriteToggle(pk) {
         if (pk === null || pk === undefined) return;
@@ -274,56 +308,10 @@
         shareAnchor.title = `⛽ ${s.name}`;
         updateFavoriteToggle(s.pk);
     }
-    async function openFavorites() {
-        const myId = ++favoritesRequestId;
+    function openFavorites() {
         qs('#station-info').classList.add('hidden');
         qs('#fuel-selector').classList.add('hidden');
-        const panel = qs('#favorites'),
-            list = panel.querySelector('ul'),
-            empty = panel.querySelector('.empty'),
-            loading = panel.querySelector('.loading');
-        panel.classList.remove('hidden');
-        list.replaceChildren();
-        empty.classList.add('hidden');
-        loading.classList.add('hidden');
-        const favs = loadFavorites();
-        if (favs.length === 0) {
-            empty.classList.remove('hidden');
-            return;
-        }
-        if (!favoritesPromise) refreshFavorites();
-        if (!favoritesPromise.resolved) loading.classList.remove('hidden');
-        const byId = await favoritesPromise;
-        if (myId !== favoritesRequestId) return;
-        loading.classList.add('hidden');
-        const validFavs = favs.filter(id => byId.has(id));
-        if (validFavs.length !== favs.length) saveFavorites(validFavs);
-        if (validFavs.length === 0) {
-            empty.classList.remove('hidden');
-            return;
-        }
-        const rowTemplate = qs('#favorite-row');
-        validFavs.forEach((id) => {
-            const s = byId.get(id),
-                li = rowTemplate.content.firstElementChild.cloneNode(true);
-            li.dataset.id = id;
-            li.querySelector('.name').textContent = s.name;
-            li.querySelector('.city').textContent = [s.city, s.postal_code].filter(Boolean).join(', ');
-            li.querySelector('.price').textContent = s[fuel] ? s[fuel].toLocaleString('es', currencyOptions) : '--';
-            li.querySelector('.row').addEventListener('click', () => {
-                panel.classList.add('hidden');
-                map.setView(s.location, 15);
-                showStation(s);
-            });
-            li.querySelector('.remove').addEventListener('click', (e) => {
-                e.stopPropagation();
-                toggleFavorite(id);
-                li.remove();
-                if (loadFavorites().length === 0) empty.classList.remove('hidden');
-                if (currentStationId === id) updateFavoriteToggle(currentStationId);
-            });
-            list.appendChild(li);
-        });
+        qs('#favorites').classList.remove('hidden');
     }
     async function updateStations(force) {
         const params = new URLSearchParams(),
@@ -446,7 +434,7 @@
         map.locate({setView: true, maxZoom: 13, enableHighAccuracy: true, maximumAge: 10});
     }
     updateStations();
-    if (loadFavorites().length > 0) refreshFavorites();
+    renderFavorites();
 
     map.attributionControl.setPrefix(false);
 
@@ -459,12 +447,11 @@
         markers = [];
         qs('#fuel-selector').classList.add('hidden');
         updateStations(true);
+        renderFavorites();
     });
 
     qs('#favorite-toggle').addEventListener('click', () => {
-        if (currentStationId === null) return;
-        toggleFavorite(currentStationId);
-        updateFavoriteToggle(currentStationId);
+        if (currentStationId !== null) toggleFavorite(currentStationId);
     });
 
     qs('#favorites-close').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Star toggle on the station info panel marks a station as favorite; favorites live client-side in `localStorage`.
- New "Favoritos" panel (opened from a star control on the map) lists saved stations with their current price for the selected fuel and lets you jump to one or remove it.
- `/stations/?ids=1,2,3` filters the response to the requested IDs (preserving order, skipping unknown/malformed entries) so the favorites panel fetches only what it needs in a single request. `ids` takes precedence over `center`.

## Test plan
- [x] `go test ./...` (runs via the pre-commit hook in Docker)
- [ ] In the browser: open a station, tap the star, reload, open the Favoritos panel — saved station appears with current price.
- [ ] Tap a row → map recenters and the station info panel opens with the star filled in.
- [ ] Tap the × on a row → station is removed; empty state shows when none remain.
- [ ] Switch fuel selector → reopen Favoritos → prices reflect the new fuel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)