### PR TITLE
Scroll the price sparkline horizontally on narrow screens

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -108,7 +108,8 @@
             line-height: 1;
             color: dimgray;
             letter-spacing: 1px;
-            word-break: break-all;
+            white-space: nowrap;
+            overflow-x: auto;
         }
         #price-chart .range {
             display: flex;
@@ -334,7 +335,8 @@
         }).join('');
 
         const fmt = v => v.toLocaleString('es', currencyOptions);
-        qs('#price-chart .spark').textContent = spark;
+        const sparkEl = qs('#price-chart .spark');
+        sparkEl.textContent = spark;
         qs('#price-chart .from').textContent = `${fmt(lo)} – ${fmt(hi)}`;
 
         const dayMs = 86400 * 1000,
@@ -345,6 +347,8 @@
             `${dateFmt(startDate)} – ${dateFmt(new Date(endDate.getTime() - dayMs))}`;
 
         chart.classList.remove('hidden');
+        // Default to the right edge so the most recent days are shown first.
+        sparkEl.scrollLeft = sparkEl.scrollWidth;
     }
     function showStation(s) {
         currentStationId = s.pk;


### PR DESCRIPTION
## What

On small screens the price-history sparkline was wider than the station panel and wrapped onto a second line, breaking the single-line reading of the chart.

This makes the sparkline scroll horizontally instead:
- `.spark` now uses `white-space: nowrap` + `overflow-x: auto` (was `word-break: break-all`).
- `renderChart` scrolls the spark element to its right edge after it's shown, so the most recent days (right side = today) are visible first; users can scroll left for older days.

Frontend-only change in `templates/home.html`. No backend/data changes — the history payload and `renderChart` data logic are untouched.

## Test

- Pre-commit hook (`go test ./...` in Docker) passes — no Go code affected.
- Manual: on a ~320px viewport the line stays on one row and scrolls; it lands at the right edge on open; wide viewports show no scrollbar and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)