### PR TITLE
Pin sparkline font so block glyphs align in Chrome desktop

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -103,7 +103,10 @@
         }
         #price-chart .spark {
             display: block;
-            font-family: monospace;
+            /* Pin a font whose block glyphs are bottom-aligned; Chrome's
+               default monospace fallback renders them with inconsistent
+               baselines, jittering the sparkline vertically. */
+            font-family: 'DejaVu Sans Mono', 'Noto Sans Mono', 'Liberation Mono', monospace;
             font-size: 1.2rem;
             line-height: 1;
             color: dimgray;


### PR DESCRIPTION
## Problem

The unicode block-glyph sparkline (`▁▂▃▄▅▆▇█`) in the station panel renders correctly on Chrome mobile, Firefox mobile, and Firefox desktop, but on **Chrome desktop** the glyphs are vertically misaligned — they jitter up and down instead of all sitting on a common baseline.

## Cause

Chrome desktop pulls these "Block Elements" glyphs from a different fallback font than Firefox does, and in that font they aren't bottom-aligned consistently. There's no per-character `vertical-align` within a single text run, so the fix is to pin a monospace font whose block glyphs are bottom-aligned.

## Change

Frontend-only, one CSS rule in `templates/home.html`: set `.spark`'s `font-family` to a stack of monospace fonts known to render the block glyphs consistently (`DejaVu Sans Mono`, `Noto Sans Mono`, `Liberation Mono`), falling back to generic `monospace`.

No backend, data, or behavior changes — so the Go test suite is unaffected (pre-commit `go test ./...` passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)